### PR TITLE
updated check in queryPinCommand() for alpha0

### DIFF
--- a/src/org/irmacard/idemix/IdemixSmartcard.java
+++ b/src/org/irmacard/idemix/IdemixSmartcard.java
@@ -583,7 +583,7 @@ public class IdemixSmartcard {
     public static ProtocolCommands queryPinCommand(CardVersion cv, byte pinID) {
         ProtocolCommands commands = new ProtocolCommands();
 
-        if (!cv.older(new CardVersion(0,8))) {
+        if (!cv.older(new CardVersion(0,8, null, "alpha0", 0))) {
             commands.add(new ProtocolCommand(
                         "querypin",
                         "Query PIN verification status",


### PR DESCRIPTION
The queryPinCommand() method from IdemixSmartcard.java always returns -1 for the last versions of the IRMA card e.g. alpha0, beta0. I've updated this check.
