### PR TITLE
The emulator should still be 'opened'

### DIFF
--- a/src/org/irmacard/credentials/idemix/smartcard/SmartCardEmulatorService.java
+++ b/src/org/irmacard/credentials/idemix/smartcard/SmartCardEmulatorService.java
@@ -84,6 +84,9 @@ public class SmartCardEmulatorService extends CardService {
 
 	@Override
 	public ResponseAPDU transmit(CommandAPDU apdu) throws CardServiceException {
+		if (!open) {
+			throw new CardServiceException("Card hasn't been opened");
+		}
 		return card.processAPDU(apdu);
 	}
 


### PR DESCRIPTION
Even though it has no real life meaning, it'd be better if it still checked if the CardService were 'opened' just like any other CardService: closing has meaning even in this version and forgetting to open a CardService throws a CardServiceException in any other CardService.

Most importantly: If you're using this emulator in unit tests you would want them to fail if you forgot to call `open()`.
